### PR TITLE
Changed getDeltaTime to getRawDeltaTime

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/hubris/relics/CrackedHourglass.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/hubris/relics/CrackedHourglass.java
@@ -81,9 +81,9 @@ public class CrackedHourglass extends HubrisRelic
         if (counter > 0) {
             if (!isStopped()) {
                 if (waitTimer <= 0) {
-                    timeCounter -= Gdx.graphics.getDeltaTime();
+                    timeCounter -= Gdx.graphics.getRawDeltaTime();
                 } else {
-                    waitTimer -= Gdx.graphics.getDeltaTime();
+                    waitTimer -= Gdx.graphics.getRawDeltaTime();
                 }
                 setCounter((int)timeCounter);
             }
@@ -100,7 +100,7 @@ public class CrackedHourglass extends HubrisRelic
                     waitTimer = 1.0f;
                 }
             } else {
-                waitTimer -= Gdx.graphics.getDeltaTime();
+                waitTimer -= Gdx.graphics.getRawDeltaTime();
             }
         }
     }


### PR DESCRIPTION
getDeltaTime will be manipulated by SuperFastMode. This would mean the player actually has way less time that intended since SuperFastMode multiplies the Delta Time.
To circumvent this use getRawDeltaTime when you need accurate time measurement through delta time
The implementation is exactly the same, it just returns the deltaTime field of the graphics object