### PR TITLE
Support triggerOnOtherCardPlayed() in DuctTapeCard

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/mod/hubris/cards/DuctTapeCard.java
+++ b/src/main/java/com/evacipated/cardcrawl/mod/hubris/cards/DuctTapeCard.java
@@ -794,6 +794,14 @@ public class DuctTapeCard extends CustomCard
             c.triggerOnManualDiscard();
         }
     }
+    
+    @Override
+    public void triggerOnOtherCardPlayed(AbstractCard cardPlayed)
+    {
+        for (AbstractCard c : cards) {
+            c.triggerOnOtherCardPlayed(cardPlayed);
+        }
+    }
 
     @Override
     public boolean canUpgrade()


### PR DESCRIPTION
Some mods like The Cursed have some unplayable cards relying on triggerOnOtherCardPlayed(), which doesn't work in current DuctTapeCard.